### PR TITLE
EDGECLOUD-1721 : Timeout on token expire

### DIFF
--- a/src/services/serviceMC.js
+++ b/src/services/serviceMC.js
@@ -26,22 +26,27 @@ function getHeader(request) {
     return headers;
 }
 
-const showError = (message) =>
+const showError = (request, message) =>
 {
-    Alert.error(message, {
-        position: 'top-right',
-        effect: 'slide',
-        beep: true,
-        timeout: 'none',
-        offset: 100,
-        html:true
-    });
+    let showMessage = request.showMessage === undefined ? true : request.showMessage;
+    if (showMessage) {
+        Alert.error(message, {
+            position: 'top-right',
+            effect: 'slide',
+            beep: true,
+            timeout: 3000,
+            offset: 100,
+            html: true
+        });
+    }
 }
 
 const checkExpiry = (self, message) => {
-    if (message.indexOf('Expired') > -1 && self.gotoUrl) {
-        setTimeout(() => self.gotoUrl('/logout'), 4000);
+    let isExpired  = message.indexOf('expired') > -1
+    if (isExpired && self.gotoUrl) {
+        setTimeout(() => self.gotoUrl('/logout'), 2000);
     }
+    return !isExpired;
 }
 
 function responseError(self, request, response, callback) {
@@ -51,8 +56,10 @@ function responseError(self, request, response, callback) {
             if(response.data && response.data.message)
             {
                 message = response.data.message
-                showError(message);
-                checkExpiry(self, message);
+                if(checkExpiry(self, message))
+                {
+                    showError(request, message);
+                }
             }
             callback({request:request, error:{code:code, message:message}})
     }

--- a/src/sites/siteFour/siteFour.js
+++ b/src/sites/siteFour/siteFour.js
@@ -808,7 +808,7 @@ class SiteFour extends React.Component {
         let store = localStorage.PROJECT_INIT ? JSON.parse(localStorage.PROJECT_INIT) : null
         this.setState({devData:[]})
         _self.loadCount = 0;
-        serviceMC.sendRequest(_self, { token: store.userToken, method: serviceMC.getEP().SHOW_SELF, data: '{}' }, _self.receiveResult)
+        serviceMC.sendRequest(_self, { token: store.userToken, method: serviceMC.getEP().SHOW_SELF, data: '{}',showMessage:false }, _self.receiveResult)
     }
 
     /** audit ********/


### PR DESCRIPTION
- User is thrown back to login page on token expiry

note : There is no standard error defined for expired token, therefore we use string to check if token is expired, token expiry must have a unique error code for better handling


