### PR TITLE
EDGECLOUD-1808 [WebUI-Monitoring] Replace "Transition Of CPU Usage" a…

### DIFF
--- a/src/sites/siteFour/monitoring/PageMonitoring.js
+++ b/src/sites/siteFour/monitoring/PageMonitoring.js
@@ -831,7 +831,7 @@ export default hot(withRouter(connect(mapStateToProps, mapDispatchProps)(sizeMe(
                     <div className='page_monitoring_dual_container'>
                         <div className='page_monitoring_title_area'>
                             <div className='page_monitoring_title'>
-                                Transition Of CPU Usage
+                                CPU Usage
                             </div>
                         </div>
                         <div className='page_monitoring_container'>
@@ -864,7 +864,7 @@ export default hot(withRouter(connect(mapStateToProps, mapDispatchProps)(sizeMe(
                     <div className='page_monitoring_dual_container'>
                         <div className='page_monitoring_title_area'>
                             <div className='page_monitoring_title'>
-                                Transition Of MEM Usage
+                                MEM Usage
                             </div>
                         </div>
                         <div className='page_monitoring_container'>
@@ -894,7 +894,7 @@ export default hot(withRouter(connect(mapStateToProps, mapDispatchProps)(sizeMe(
                     <div className='page_monitoring_dual_container'>
                         <div className='page_monitoring_title_area'>
                             <div className='page_monitoring_title'>
-                                Transition Of DISK Usage
+                                DISK Usage
                             </div>
                         </div>
                         <div className='page_monitoring_container'>
@@ -922,7 +922,7 @@ export default hot(withRouter(connect(mapStateToProps, mapDispatchProps)(sizeMe(
                     <div className='page_monitoring_dual_container'>
                         <div style={{display: 'flex', flexDirection: 'row'}}>
                             <div className='page_monitoring_title_select' style={{marginTop: 7}}>
-                                Transition Of Connections
+                                Connections
                             </div>
                             {!this.state.loading &&
                             <Dropdown
@@ -977,7 +977,7 @@ export default hot(withRouter(connect(mapStateToProps, mapDispatchProps)(sizeMe(
                     <div className='page_monitoring_dual_container'>
                         <div className='page_monitoring_title_area'>
                             <div className='page_monitoring_title_select'>
-                                Transition Of NETWORK Usage
+                                NETWORK Usage
                             </div>
                             {!this.state.loading &&
                             <Dropdown


### PR DESCRIPTION
EDGECLOUD-1808 [WebUI-Monitoring] Replace "Transition Of CPU Usage" and "Transition Of Network Usage" with "CPU Usage" and "Network Usage" respectively