### PR TITLE
EDGECLOUD-1769 - Fixed State in detail page for appoints

### DIFF
--- a/src/container/pageDetailViewer.js
+++ b/src/container/pageDetailViewer.js
@@ -154,7 +154,8 @@ const _status = {
     "10": "Deleting",
     "11": "Delete Error",
     "12": "Delete Prepare",
-    "13": "CRM Init"
+    "13": "CRM Init",
+    "14": "Creating"
 }
 const _liveness = {
     "1": "Static",


### PR DESCRIPTION
We show creating instead of creating dependencies, since to update the state we need to call showAppInst request multiple times which is expensive and hence by default we show creating