### PR TITLE
EDGECLOUD-2460 Edge WebUI version label is vv1.1.108 instead of v1.1.108

### DIFF
--- a/src/sites/siteFour/siteFour.js
+++ b/src/sites/siteFour/siteFour.js
@@ -129,7 +129,7 @@ class SiteFour extends React.Component {
             token: token,
             method: serviceMC.getEP().SHOW_CONTROLLER
         }, _self.receiveControllerResult);
-        _self.setState({currentVersion: process.env.REACT_APP_BUILD_VERSION ? "v"+ process.env.REACT_APP_BUILD_VERSION : 'v0.0.0'})
+        _self.setState({currentVersion: process.env.REACT_APP_BUILD_VERSION ? process.env.REACT_APP_BUILD_VERSION : 'v0.0.0'})
     }
 
 


### PR DESCRIPTION
EDGECLOUD-2460 Edge WebUI version label is vv1.1.108 instead of v1.1.108