### PR TITLE
EDGECLOUD-2460 Edge WebUI version label is vv1.1.108 instead of v1.1.108

### DIFF
--- a/src/sites/siteFour/defaultLayout/sideNav.js
+++ b/src/sites/siteFour/defaultLayout/sideNav.js
@@ -284,7 +284,7 @@ export default function MiniDrawer(props) {
 
     const versionInfo = () => (
         <div style={{position: 'absolute', bottom: 5, marginLeft: 10, color: '#B1B2B4'}}>
-            {process.env.REACT_APP_BUILD_VERSION ? "v" + process.env.REACT_APP_BUILD_VERSION : 'v0.0.0'}
+            {process.env.REACT_APP_BUILD_VERSION ? process.env.REACT_APP_BUILD_VERSION : 'v0.0.0'}
         </div>
     )
 


### PR DESCRIPTION
EDGECLOUD-2460 Edge WebUI version label is vv1.1.108 instead of v1.1.108