### PR TITLE
EDGECLOUD-2597 Cannot read property 'changeZoom' occurs when navigating from Audit Logs to Privacy Policy

### DIFF
--- a/src/components/timeline/calendarTimeline.js
+++ b/src/components/timeline/calendarTimeline.js
@@ -249,7 +249,11 @@ export default class CalendarTimeline extends React.PureComponent {
 
     componentDidMount() {
         let _self = this;
-        setTimeout(() => _self.timeline.changeZoom(0.1), 500);
+        setTimeout(() => {
+            if (_self && _self.timeline) {
+                _self.timeline.changeZoom(0.1)
+            }
+        }, 500)
     }
 
     componentDidUpdate(prevProps, prevState, snapshot) {


### PR DESCRIPTION
This was due to timeout option used in audit log which was trying modify to object which was destroyed when menu option was changed