### PR TITLE
Edgecloud 2970 ,  edgecloud 2960

### DIFF
--- a/.env
+++ b/.env
@@ -2,4 +2,4 @@ GENERATE_SOURCEMAP=false
 SKIP_PREFLIGHT_CHECK=true
 REACT_APP_API_ENDPOINT = "https://console-stage.mobiledgex.net:443"
 REACT_APP_BUILD_VERSION="version 2.0.6"
-PORT=3030
+PORT=3000


### PR DESCRIPTION
Edgecloud 2970 ,  edgecloud 2960
-Do not display super granular scales down number in Graphs for CPU Usage and Connection Graphs

-Fix timing graph for all monitoring view (Developer, Operator)for all metric graphs