### PR TITLE
EDGECLOUD-3200, 3222 Map not shown on cloudlet update, Switching from Graph to the Cloudlet Location does not show 

### DIFF
--- a/src/hoc/maps/MexMap.js
+++ b/src/hoc/maps/MexMap.js
@@ -125,7 +125,6 @@ class ClustersMap extends Component {
         }
         this.setState({ oldCountry: this.state.selectedCity })
         let catchLeafLayer = document.getElementsByClassName("leaflet-tile-container");
-        console.log("20200719 .. ", catchLeafLayer);
         if(catchLeafLayer) {
             if(catchLeafLayer.length === 0) {
                 this.handleRefresh();


### PR DESCRIPTION
- solve below -->
EDGECLOUD-3200 Map not shown on cloudlet updatechanges location
EDGECLOUD-3222 Webui Switching from Graph to the Cloudlet Location does not show the map, the hand pointer changes 
- remove the ContainerDimensions that calculate screen size