### PR TITLE
EDGECLOUD-5824 Web server version information disclosed in error pages

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -12,4 +12,5 @@ RUN npm run build
 
 FROM nginx:stable
 
+COPY docker-nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /edge-cloud-ui/build /usr/share/nginx/html

--- a/docker-nginx.conf
+++ b/docker-nginx.conf
@@ -1,0 +1,16 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+    server_tokens off;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
Override default nginx config and set "server_tokens off" in the prod
console image.